### PR TITLE
Add ability to optionally ignore a directory

### DIFF
--- a/plugin/vim-erlang-tags.vim
+++ b/plugin/vim-erlang-tags.vim
@@ -21,7 +21,13 @@ endif
 
 autocmd FileType erlang call VimErlangTagsDefineMappings()
 
-let s:exec_script = expand('<sfile>:p:h') . "/../bin/vim-erlang-tags.erl"
+let s:script_opts = ""
+
+if exists("g:erlang_tags_ignore") && g:erlang_tags_ignore != ""
+    let s:script_opts = " --ignore " . g:erlang_tags_ignore
+endif
+
+let s:exec_script = expand('<sfile>:p:h') . "/../bin/vim-erlang-tags.erl" . s:script_opts
 
 function! VimErlangTags()
     let script_output = system(s:exec_script)


### PR DESCRIPTION
vim-erlang-tags.erl now takes a `--ignore Name` option (or `-i Name`), which it will ignore. `Name` is expanded using `filelib:wildcard/1`, so it can be a glob-match. This can be specified multiple times for multiple ignores. It can be a filename or dirname.

vim-erlang-tags.vim: specify `g:erlang_tags_ignore` in vimrc as follows:

```
 let g:erlang_tags_ignore = "_rel"
```

Known issues: can only specify one ignore pattern in vimrc
