### PR TITLE
Add g:erlang_tags_outfile option to specify tags output file

### DIFF
--- a/plugin/vim-erlang-tags.vim
+++ b/plugin/vim-erlang-tags.vim
@@ -27,6 +27,10 @@ if exists("g:erlang_tags_ignore") && g:erlang_tags_ignore != ""
     let s:script_opts = " --ignore " . g:erlang_tags_ignore
 endif
 
+if exists("g:erlang_tags_outfile") && g:erlang_tags_outfile != ""
+    let s:script_opts = s:script_opts . " --output " . g:erlang_tags_outfile
+endif
+
 let s:exec_script = expand('<sfile>:p:h') . "/../bin/vim-erlang-tags.erl" . s:script_opts
 
 function! VimErlangTags()


### PR DESCRIPTION
The script provides `-o, --output FILE` option, but it's not available from the plugin. This change addresses that.
