### PR TITLE
(#14) Jump to record/marco after '#' or '?'

### DIFF
--- a/bin/vim-erlang-tags.erl
+++ b/bin/vim-erlang-tags.erl
@@ -317,14 +317,14 @@ add_func_tags(Tags, File, ModName, FuncName) ->
 % File contains a macro or record called Name; add this information to Tags.
 add_record_or_macro_tag(Tags, File, Attribute, Name) ->
 
-    Kind =
+    {Kind, Prefix} =
         case Attribute of
             <<"record">> ->
                 log("Record found: ~s~n", [Name]),
-                $r;
+                {$r, $#};
             <<"define">> ->
                 log("Macro found: ~s~n", [Name]),
-                $d
+                {$d, $?}
         end,
 
     Scope =
@@ -337,9 +337,17 @@ add_record_or_macro_tag(Tags, File, Attribute, Name) ->
 
     % myrec  ./mymod.erl  /^-record\.\*\<myrec\>/;"  r  file:
     % myrec  ./myhrl.hrl  /^-record\.\*\<myrec\>/;"  r
-    % myrec  ./mymod.erl  /^-define\.\*\<mymac\>/;"  m  file:
-    % myrec  ./myhrl.hrl  /^-define\.\*\<mymac\>/;"  m
+    % mymac  ./mymod.erl  /^-define\.\*\<mymac\>/;"  m  file:
+    % mymac  ./myhrl.hrl  /^-define\.\*\<mymac\>/;"  m
     add_tag(Tags, Name, File,
+            ["/^-\\s\\*", Attribute, "\\s\\*(\\s\\*", Name, "\\>/"],
+            Scope, Kind),
+
+    % #myrec  ./mymod.erl  /^-record\.\*\<myrec\>/;"  r  file:
+    % #myrec  ./myhrl.hrl  /^-record\.\*\<myrec\>/;"  r
+    % ?mymac  ./mymod.erl  /^-define\.\*\<mymac\>/;"  m  file:
+    % ?mymac  ./myhrl.hrl  /^-define\.\*\<mymac\>/;"  m
+    add_tag(Tags, [Prefix|Name], File,
             ["/^-\\s\\*", Attribute, "\\s\\*(\\s\\*", Name, "\\>/"],
             Scope, Kind).
 

--- a/plugin/vim-erlang-tags.vim
+++ b/plugin/vim-erlang-tags.vim
@@ -43,7 +43,10 @@ command! ErlangTags call VimErlangTags()
 function! VimErlangTagsSelect()
     let orig_isk = &isk
     set isk+=:
-    normal "_vaw
+    normal "_vawo
+    if getline('.')[col('.') - 2] =~# '[#?]'
+        normal h
+    endif
     let &isk = orig_isk
 endfunction
 


### PR DESCRIPTION
vim-erlang-tags.erl generates extra tags (#rec for records), and when C-] is
hit on a record, the # is counted as part of the name, so only records tags
will be considered. If there are several records with the same name, it is
still not guaranteed that C-] will jump to the correct one.

Same was implemented for macros and '?'.
