### PR TITLE
make AsyncVimErlangTags take parameters

### DIFF
--- a/plugin/vim-erlang-tags.vim
+++ b/plugin/vim-erlang-tags.vim
@@ -54,10 +54,7 @@ function! VimErlangTags()
 endfunction
 
 function! AsyncVimErlangTags(...)
-    let param = ""
-    for elem in a:000
-        let param = param . " " . elem
-    endfor
+    let param = join(a:000, " ")
     let exec_cmd = s:GetExecuteCmd()
     call system(exec_cmd . " " . param . " " . '&')
 endfunction

--- a/plugin/vim-erlang-tags.vim
+++ b/plugin/vim-erlang-tags.vim
@@ -53,9 +53,13 @@ function! VimErlangTags()
     endif
 endfunction
 
-function! AsyncVimErlangTags()
+function! AsyncVimErlangTags(...)
+    let param = ""
+    for elem in a:000
+        let param = param . " " . elem
+    endfor
     let exec_cmd = s:GetExecuteCmd()
-    call system(exec_cmd . '&')
+    call system(exec_cmd . " " . param . " " . '&')
 endfunction
 
 command! ErlangTags call VimErlangTags()


### PR DESCRIPTION
Make `AsyncVimErlangTags` take varargs to be given to the escript, to make it easier to call from vim command mode