### PR TITLE
README: vim-erlang-tags.erl → vim_erlang_tags.erl

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ First you need to generate the tags.
 You can do that either in the command line:
 
     $ cd /path/to/my_erlang_project
-    $ /path/to/vim-erlang-tags/bin/vim-erlang-tags.erl
+    $ /path/to/vim-erlang-tags/bin/vim_erlang_tags.erl
 
 Or within Vim by executing the following command:
 
@@ -104,7 +104,7 @@ automate the process by creating a commit/checkout hook or a crontab entry.
 If you use Git, creating a checkout hook is simple:
 
     echo '#!/bin/bash' > .git/hooks/post-checkout
-    echo '/path/to/vim-erlang-tags/bin/vim-erlang-tags.erl' > .git/hooks/post-checkout
+    echo '/path/to/vim-erlang-tags/bin/vim_erlang_tags.erl' > .git/hooks/post-checkout
     chmod +x .git/hooks/post-checkout
     cp -i .git/hooks/post-checkout .git/hooks/post-commit
 


### PR DESCRIPTION
Commit 7d6f07963f95e4a7b86ab6184eba6dbe0470a8ca renamed vim-erlang-tags.erl to vim_erlang_tags.erl.

This commit updates the README accordingly.