### PR TITLE
Build OTP tags and add to vim tags path

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,27 @@ Or within Vim by executing the following command:
 Note that for the latter command, the current working directory will be used
 (`:help pwd` to find out more).
 
+### Generate OTP tags
+
+Often, you might be curious about the implementation of that function from the
+OTP libraries, but `CTRL-t` is not taking you there. We have a solution for
+this:
+
+    call AsyncBuildOtpTags()
+
+This command will find the path to your otp installation, and inside its `lib/`
+folder, it will build a tags file called `otptags`. The next thing you need, is
+to make vim aware of this. That's where the next function comes in place:
+
+    call GetOtpTagsPath()
+
+This will return the path to the generated `otptags` file, wherever this file
+lives. Extract it, and add it to your tags by doing
+
+    let &tags.="," . otptags_path
+
+Where otptags\_path is the expanded path returned previously.
+
 ### Options
 
 #### `g:erlang_tags_ignore`

--- a/plugin/vim-erlang-tags.vim
+++ b/plugin/vim-erlang-tags.vim
@@ -22,6 +22,7 @@ endif
 autocmd FileType erlang call VimErlangTagsDefineMappings()
 
 let s:exec_script = expand('<sfile>:p:h') . "/../bin/vim_erlang_tags.erl"
+let s:otppath_cmd = 'erl -noinput -eval ''io:format("~ts", [code:lib_dir()]), init:stop().'''
 
 function! s:GetExecuteCmd()
     let script_opts = ""
@@ -40,6 +41,17 @@ function! s:GetExecuteCmd()
         let script_opts = script_opts . " --output " . g:erlang_tags_outfile
     endif
     return s:exec_script . script_opts
+endfunction
+
+function! GetOtpTagsPath()
+    let otppath = system(s:otppath_cmd)
+    let otptags = otppath . "/otptags"
+    return otptags
+endfunction
+
+function! AsyncBuildOtpTags()
+    let cmd = '(OTPPATH=`' . s:otppath_cmd . '` && ' . s:exec_script . ' -i $OTPPATH -o $OTPPATH/otptags)'
+    call system(cmd . " &")
 endfunction
 
 function! VimErlangTags(...)
@@ -104,7 +116,7 @@ if !exists("s:os")
 endif
 
 " https://vim.fandom.com/wiki/Autocmd_to_update_ctags_file
-function! DelTagOfFile(file)
+function! s:DelTagOfFile(file)
   let fullpath = a:file
   let cwd = getcwd()
   let tagfilename = cwd . "/tags"


### PR DESCRIPTION
This is very useful in case you like having tags to OTP libs at hand, in many projects, and building tags for each project with the otp tags seems redundant. Like this, you can have one global otptags for all your projects.